### PR TITLE
[13.0][FIX] purchase_order_type: wrong context default values passing

### DIFF
--- a/purchase_order_type_advanced/README.rst
+++ b/purchase_order_type_advanced/README.rst
@@ -48,6 +48,7 @@ Contributors
 ~~~~~~~~~~~~
 
 * Christian Santamaría <christian.santamaria@solvos.es>
+* David Alonso <david.alonso@solvos.es>
 
 Maintainers
 ~~~~~~~~~~~

--- a/purchase_order_type_advanced/__manifest__.py
+++ b/purchase_order_type_advanced/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.1.0.0",
+    "version": "13.0.1.0.1",
     'category': "Operations/Purchase",
     "website": "https://github.com/solvosci/slv-purchase",
     "depends": [

--- a/purchase_order_type_advanced/models/account_move.py
+++ b/purchase_order_type_advanced/models/account_move.py
@@ -19,7 +19,6 @@ class AccountMove(models.Model):
 
     @api.depends("partner_id", "company_id")
     def _compute_purchase_type_id(self):
-        self.purchase_type_id = self.env["purchase.order.type"]
         for record in self.filtered(
             lambda am: am.type in ["in_invoice", "in_refund"]
         ):

--- a/purchase_order_type_advanced/models/purchase_order.py
+++ b/purchase_order_type_advanced/models/purchase_order.py
@@ -23,8 +23,10 @@ class PurchaseOrder(models.Model):
 
     def action_view_invoice(self):
         res = super(PurchaseOrder, self).action_view_invoice()
+        ctx = {}
         if self.order_type.journal_id:
-            res["default_journal_id"] = self.order_type.journal_id.id
+            ctx["default_journal_id"] = self.order_type.journal_id.id
         if self.order_type:
-            res["default_purchase_type_id"] = self.order_type.id
+            ctx["default_purchase_type_id"] = self.order_type.id
+        res["context"].update(ctx)
         return res

--- a/purchase_order_type_advanced/readme/CONTRIBUTORS.rst
+++ b/purchase_order_type_advanced/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Christian Santamaría <christian.santamaria@solvos.es>
+* David Alonso <david.alonso@solvos.es>

--- a/purchase_order_type_advanced/static/description/index.html
+++ b/purchase_order_type_advanced/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
 <title>Purchase Order Type Advanced</title>
 <style type="text/css">
 
@@ -401,6 +401,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <h2><a class="toc-backref" href="#id4">Contributors</a></h2>
 <ul class="simple">
 <li>Christian SantamarÃ­a &lt;<a class="reference external" href="mailto:christian.santamaria&#64;solvos.es">christian.santamaria&#64;solvos.es</a>&gt;</li>
+<li>David Alonso &lt;<a class="reference external" href="mailto:david.alonso&#64;solvos.es">david.alonso&#64;solvos.es</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/purchase_order_type_advanced/views/account_move_views.xml
+++ b/purchase_order_type_advanced/views/account_move_views.xml
@@ -5,7 +5,11 @@
         <field name="inherit_id" ref="account.view_move_form" />
         <field name="arch" type="xml">
             <field name="journal_id" position="before">
-                <field name="purchase_type_id" attrs="{'invisible': [('type', 'not in', ['in_invoice', 'in_refund'])]}"/>
+                <field
+                    name="purchase_type_id"
+                    attrs="{'invisible': [('type', 'not in', ['in_invoice', 'in_refund'])]}"
+                    readonly="context.get('default_purchase_type_id', False)"
+                />
             </field>
         </field>
     </record>


### PR DESCRIPTION
When Create Bill is clicked from a purchase order, two issues are were faced:

- Default Journal is not filled.
- Default purchase order type is not filled.

This PR fixes both. Also, in this fix/improvement, purchase order type for a vendor bill becomes readonly when accessing from purchase order.