### PR TITLE
[13.0][IMP] purchase_order_confirm_receive: remove order form button

### DIFF
--- a/purchase_order_confirm_receive/__manifest__.py
+++ b/purchase_order_confirm_receive/__manifest__.py
@@ -8,7 +8,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.1.0.0",
+    "version": "13.0.1.1.0",
     'category': "Operations/Purchase",
     "website": "https://github.com/solvosci/slv-purchase",
     "depends": ["purchase_stock"],

--- a/purchase_order_confirm_receive/views/purchase_order_views.xml
+++ b/purchase_order_confirm_receive/views/purchase_order_views.xml
@@ -10,24 +10,4 @@
             action = model.action_batch_confirm_receive()
         </field> 
     </record>
-
-    <record id="purchase_order_form" model="ir.ui.view">
-        <field name="name">
-            purchase.order.form (in purchase_order_confirm_receive)
-        </field>
-        <field name="model">purchase.order</field>
-        <field name="inherit_id" ref="purchase.purchase_order_form" />
-        <field name="arch" type="xml">
-            <button name="button_confirm" position="after">
-                <button
-                    name="button_confirm_receive"
-                    type="object"
-                    string="Confirm and receive"
-                    class="oe_highlight"
-                    attrs="{'invisible': [('state','not in',('draft','sent'))]}"
-                />
-            </button>
-        </field>
-    </record>
-
 </odoo>


### PR DESCRIPTION
Since "Confirm and receive" is available as an action in order form, it's better removing it, in order to prevent mistakes selecting original "Confirm" button