### PR TITLE
[13.0][IMP] purchase_order_line_lowcode: invisible field

### DIFF
--- a/purchase_order_line_lowcode/__manifest__.py
+++ b/purchase_order_line_lowcode/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.1.0.0",
+    "version": "13.0.1.1.0",
     'category': "Operations/Purchase",
     "website": "https://github.com/solvosci/slv-purchase",
     "depends": ["purchase", "base_waste_mgmt_data"],

--- a/purchase_order_line_lowcode/views/purchase_order_views.xml
+++ b/purchase_order_line_lowcode/views/purchase_order_views.xml
@@ -12,7 +12,7 @@
                     expr="//field[@name='order_line']//tree//field[@name='product_id']"
                     position="after"
                 >
-                    <field name="product_low_code" optional="show"/>
+                    <field name="product_low_code" optional="show" invisible="1"/>
                 </xpath>
                 <xpath
                     expr="//field[@name='order_line']//form//field[@name='product_id']"
@@ -21,6 +21,7 @@
                     <field
                         name="product_low_code" 
                         attrs="{'invisible': [('product_low_code','=',False)]}"
+                        invisible="1"
                     />
                 </xpath>
             </field>


### PR DESCRIPTION
Change the field to invisible to use only the interface_gaia addon in the near future.
