### PR TITLE
[13.0][FIX] purchase_order_move_menu_spil: missing dependencies

### DIFF
--- a/purchase_order_move_menu_spil/__manifest__.py
+++ b/purchase_order_move_menu_spil/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "AGPL-3",
-    "version": "13.0.1.0.0",
+    "version": "13.0.1.0.1",
     "category": "Purchase",
     "website": "https://github.com/solvosci/slv-purchase",
     "depends": [

--- a/purchase_order_move_menu_spil/migrations/13.0.1.0.1/post-migration.py
+++ b/purchase_order_move_menu_spil/migrations/13.0.1.0.1/post-migration.py
@@ -1,0 +1,14 @@
+# © 2022 Solvos Consultoría Informática (<http://www.solvos.es>)
+# License AGPL-3.0 (https://www.gnu.org/licenses/agpl-3.0.html)
+
+from odoo import SUPERUSER_ID, api
+
+
+def migrate(cr, version):
+    with api.Environment.manage():
+        env = api.Environment(cr, SUPERUSER_ID, {})
+        purchase_move_ids = env['stock.move'].search([
+            ('purchase_line_id', '!=', False),
+            ('state', '=', 'done')
+        ])
+        purchase_move_ids._compute_purchase_move_menu()

--- a/purchase_order_move_menu_spil/models/stock_move.py
+++ b/purchase_order_move_menu_spil/models/stock_move.py
@@ -43,7 +43,7 @@ class StockMove(models.Model):
         store=True
     )
 
-    @api.depends("state", "purchase_line_id.price_unit", "invoice_line_ids.move_id.state")
+    @api.depends("state", "purchase_line_id.price_unit", "invoice_line_ids.move_id.state", "invoice_line_ids.price_unit", "quantity_done")
     def _compute_purchase_move_menu(self):
         precision = self.env["decimal.precision"].precision_get(
             "Product Price"


### PR DESCRIPTION
Add invoice_line_ids.price_unit and quantity_done dependencies, update all stock move [('purchase_line_id', '!=', False), ('state', '=', 'done')] with post-migration system

Need to install it in test, I will keep the status informed...
