### PR TITLE
[14.0][FIX] purchase_order_type_advanced: bug in default purchase order type domain for input picking types

### DIFF
--- a/purchase_order_type_advanced/__manifest__.py
+++ b/purchase_order_type_advanced/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "14.0.1.0.0",
+    "version": "14.0.1.0.1",
     'category': "Operations/Purchase",
     "website": "https://github.com/solvosci/slv-purchase",
     "depends": [

--- a/purchase_order_type_advanced/views/stock_picking_type_views.xml
+++ b/purchase_order_type_advanced/views/stock_picking_type_views.xml
@@ -13,7 +13,7 @@
                 <field name="warehouse_id" position="after">
                     <field
                         name="buy_purchase_order_type_id" 
-                        domain="[('picking_type_id', 'in', [False, uid])]"
+                        domain="[('picking_type_id', 'in', [False, id])]"
                         attrs="{'invisible': [('code', '!=', 'incoming')]}"
                     />
                 </field>


### PR DESCRIPTION
Fixes a typo between `uid` and `id` when selecting a proper domain in a `many2one` field