### PR TITLE
[14.0][FIX] purchase_order_type_advanced: batch invoice creation for more than purchase type

### DIFF
--- a/purchase_order_type_advanced/__manifest__.py
+++ b/purchase_order_type_advanced/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "14.0.1.0.1",
+    "version": "14.0.1.0.2",
     'category': "Operations/Purchase",
     "website": "https://github.com/solvosci/slv-purchase",
     "depends": [

--- a/purchase_order_type_advanced/models/purchase_order.py
+++ b/purchase_order_type_advanced/models/purchase_order.py
@@ -26,9 +26,17 @@ class PurchaseOrder(models.Model):
     def action_view_invoice(self, invoices=False):
         res = super().action_view_invoice(invoices=invoices)
         ctx = ast.literal_eval(res.get("context", "{}"))
-        if self.order_type.journal_id:
-            ctx["default_journal_id"] = self.order_type.journal_id.id
-        if self.order_type:
-            ctx["default_purchase_type_id"] = self.order_type.id
+        if invoices:
+            # Batch invoice creation: first invoice rules for extra default
+            #  values in case of later new invoice creation
+            ctx.update({
+                "default_journal_id": invoices[0].journal_id.id or False,
+                "default_purchase_type_id": invoices[0].purchase_type_id.id or False,
+            })
+        else:
+            if self.order_type.journal_id:
+                ctx["default_journal_id"] = self.order_type.journal_id.id
+            if self.order_type:
+                ctx["default_purchase_type_id"] = self.order_type.id
         res["context"] = str(ctx)
         return res


### PR DESCRIPTION
Prior this fix, when creating invoices from a list of purchase orders (batch invoice process) an expected singleton error was raised if PO for more than one puchase order type were selected.

With this fix, the error is not thrown, and first invoice purchase order type and journal default values are selected for context (whose update raised the error)