### PR TITLE
[14.0][FIX] purchase_order_type_advanced: preserve supplier payment term in autogenerated POs

### DIFF
--- a/purchase_order_type_advanced/__manifest__.py
+++ b/purchase_order_type_advanced/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "14.0.1.0.2",
+    "version": "14.0.1.0.3",
     'category': "Operations/Purchase",
     "website": "https://github.com/solvosci/slv-purchase",
     "depends": [

--- a/purchase_order_type_advanced/models/stock_rule.py
+++ b/purchase_order_type_advanced/models/stock_rule.py
@@ -15,7 +15,9 @@ class StockRule(models.Model):
         if purchase_order_type:
             ret.update({
                 "order_type": purchase_order_type.id,
-                "payment_term_id": purchase_order_type.payment_term_id.id,
                 "incoterm_id": purchase_order_type.incoterm_id.id,
             })
+            ret.setdefault(
+                "payment_term_id", purchase_order_type.payment_term_id.id
+            )
         return ret


### PR DESCRIPTION
With this fix, payment term for autogenerated POs (e.g. from scheduler) is only assigned to the default PO type one if PO partner has no default payment term (before this fix payment term was always overwritten by POT one)