### PR TITLE
[14.0][IMP] fcd_purchase_order: change the creation of fcd.document when confirming the order

### DIFF
--- a/fcd_purchase_order/__manifest__.py
+++ b/fcd_purchase_order/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "AGPL-3",
-    "version": "14.0.1.6.1",
+    "version": "14.0.1.7.0",
     "category": "Purchase",
     "website": "https://github.com/solvosci/slv-purchase",
     "depends": [

--- a/fcd_purchase_order/models/purchase_order.py
+++ b/fcd_purchase_order/models/purchase_order.py
@@ -46,7 +46,17 @@ class PurchaseOrder(models.Model):
             'type': 'ir.actions.act_window',
         }
 
+    def button_confirm(self):
+        res = super(PurchaseOrder, self).button_confirm()
+        for order in self:
+            order.create_fcd_documents()
+        return res
+
     @api.constrains('order_line')
+    def create_line_fcd_confirmed(self):
+        if self.state in ['purchase', 'done']:
+            self.create_fcd_documents()
+
     def create_fcd_documents(self):
         for line in self.order_line.filtered(lambda x: x.product_type == 'product' and x.fcd_lot_id.id == False):
             if line.fcd_lot_name:

--- a/fcd_purchase_order/models/purchase_order_line.py
+++ b/fcd_purchase_order/models/purchase_order_line.py
@@ -7,7 +7,7 @@ from odoo import models, fields, _
 class PurchaseOrderLine(models.Model):
     _inherit = 'purchase.order.line'
 
-    fcd_document_line_id = fields.Many2one('fcd.document.line')
-    fcd_lot_name = fields.Char()
+    fcd_document_line_id = fields.Many2one('fcd.document.line', copy=False)
+    fcd_lot_name = fields.Char(copy=False)
     fcd_lot_id = fields.Many2one('stock.production.lot', related="fcd_document_line_id.lot_id")
-    fcd_lot_finished = fields.Boolean()
+    fcd_lot_finished = fields.Boolean(copy=False)

--- a/fcd_purchase_order/views/purchase_order_views.xml
+++ b/fcd_purchase_order/views/purchase_order_views.xml
@@ -6,9 +6,6 @@
         <field name="model">purchase.order</field>
         <field name="inherit_id" ref="purchase.purchase_order_form" />
         <field name="arch" type="xml">
-            <xpath expr="//form" position="attributes">
-                <attribute name="duplicate">0</attribute>
-            </xpath>
             <xpath expr="//tree/field[@name='name']" position="after">
                 <field name="fcd_lot_id" widget="many2onebutton" />
             </xpath>


### PR DESCRIPTION
Change the creation of fcd.document when confirming the order

Previously, fcd.documents were created when creating a purchase order line. This has been changed because we want the lot to be saved when confirming the order, not before, and to be able to duplicate the order.