### PR TITLE
[17.0][FIX] purchase_security_advanced: bypass suggested quantity access to sellers without access

### DIFF
--- a/purchase_security_advanced/__manifest__.py
+++ b/purchase_security_advanced/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "AGPL-3",
-    "version": "17.0.1.0.0",
+    "version": "17.0.1.0.1",
     'category': "Operations/Purchase",
     "website": "https://github.com/solvosci/slv-purchase",
     "depends": ["purchase_security"],

--- a/purchase_security_advanced/models/__init__.py
+++ b/purchase_security_advanced/models/__init__.py
@@ -1,2 +1,3 @@
 from . import res_partner
 from . import ir_rule
+from . import purchase_order_line

--- a/purchase_security_advanced/models/purchase_order_line.py
+++ b/purchase_security_advanced/models/purchase_order_line.py
@@ -1,0 +1,14 @@
+# © 2025 Solvos Consultoría Informática (<http://www.solvos.es>)
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo import models
+
+
+class PurchaseOrderLine(models.Model):
+    _inherit = "purchase.order.line"
+
+    def _suggest_quantity(self):
+        # This will look for sellers (partners), that couldn't be directly
+        #  accessed by some users. Then, permssions must be bypassed
+        self_sudo = self.sudo()
+        super(PurchaseOrderLine, self_sudo)._suggest_quantity()


### PR DESCRIPTION
When selected a product within a purchase line, suggested quantity is taken from vendor prices (supplierinfo). Those vendors are partners that could not be accessible by restricted users, raising an access error for res.partner. This fixes it.

cc @IriaAlonso @ChristianSantamaria @DantePereyra 