### PR TITLE
[17.0][FIX] purchase_security_advanced: ensure confirm PO when products with sellers unauthorized are involved

### DIFF
--- a/purchase_security_advanced/__manifest__.py
+++ b/purchase_security_advanced/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "AGPL-3",
-    "version": "17.0.1.0.1",
+    "version": "17.0.1.0.2",
     'category': "Operations/Purchase",
     "website": "https://github.com/solvosci/slv-purchase",
     "depends": ["purchase_security"],

--- a/purchase_security_advanced/models/__init__.py
+++ b/purchase_security_advanced/models/__init__.py
@@ -1,3 +1,5 @@
 from . import res_partner
 from . import ir_rule
+from . import product_product
+from . import purchase_order
 from . import purchase_order_line

--- a/purchase_security_advanced/models/product_product.py
+++ b/purchase_security_advanced/models/product_product.py
@@ -1,0 +1,29 @@
+# © 2025 Solvos Consultoría Informática (<http://www.solvos.es>)
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo import models
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    def _select_seller(
+        self,
+        partner_id=False,
+        quantity=0.0,
+        date=None,
+        uom_id=False,
+        ordered_by="price_discounted",
+        params=False
+    ):
+        product_obj = self
+        if self.env.context.get("skip_sellers_permissions", False):
+            product_obj = self.sudo()
+        return super(ProductProduct, product_obj)._select_seller(
+            partner_id=partner_id,
+            quantity=quantity,
+            date=date,
+            uom_id=uom_id,
+            ordered_by=ordered_by,
+            params=params
+        )

--- a/purchase_security_advanced/models/purchase_order.py
+++ b/purchase_security_advanced/models/purchase_order.py
@@ -4,11 +4,11 @@
 from odoo import models
 
 
-class PurchaseOrderLine(models.Model):
-    _inherit = "purchase.order.line"
+class PurchaseOrder(models.Model):
+    _inherit = "purchase.order"
 
-    def _suggest_quantity(self):
+    def _add_supplier_to_product(self):
         # This will look for sellers (partners), that couldn't be directly
         #  accessed by some users. Then, permssions must be bypassed
-        line_obj = self.with_context(skip_sellers_permissions=True)
-        super(PurchaseOrderLine, line_obj)._suggest_quantity()
+        order_obj = self.with_context(skip_sellers_permissions=True)
+        super(PurchaseOrder, order_obj)._add_supplier_to_product()


### PR DESCRIPTION
When a PO is confirmed, some stuff with products sellers is made. If user is not allowed to access to existing product sellers, an error is raised.

This is the same issue fixed by #84 at PO confirmation. The code was refactored for better covering both cases.