### PR TITLE
[15.0][FIX] purchase_stock_upd_std_price: ensure price update for limited access users

### DIFF
--- a/purchase_stock_upd_std_price/__manifest__.py
+++ b/purchase_stock_upd_std_price/__manifest__.py
@@ -8,7 +8,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "15.0.1.0.0",
+    "version": "15.0.1.0.1",
     "category": "Inventory/Purchase",
     "website": "https://github.com/solvosci/slv-purchase",
     "depends": ["purchase_stock"],

--- a/purchase_stock_upd_std_price/models/stock_move.py
+++ b/purchase_stock_upd_std_price/models/stock_move.py
@@ -36,7 +36,7 @@ class StockMove(models.Model):
         for move in moves_upd_price:
             product = move.product_id.with_company(
                 move.company_id
-            )
+            ).sudo()
             product.standard_price = move.price_unit
             post_message = _(
                 "Product price at %s have been set according to %s purchase order stock incoming",


### PR DESCRIPTION
If a product has automatic valuation method enabled and Automatic Price Update enabled as well, a journal entry will be created in some situations. Without this fix, if the user that validates a picking that will force price update has limited access, an error was raised, because a jornal entry creation attemt leads to a control access error. This fixes it.